### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/multicollections/security/code-scanning/1](https://github.com/gerlero/multicollections/security/code-scanning/1)

The best way to address this issue is to explicitly specify the minimal `permissions` setting at the top level of the workflow file (i.e., at the root, above `jobs:`), so that all jobs will inherit these minimal permissions unless overridden. For typical CI tasks like linting, type-checking, testing, and building, only read access to repository contents is required, so setting `permissions: contents: read` meets the principle of least privilege. Only expand permissions if you have a job that requires more (e.g., releasing, creating PRs), which isn't indicated here. The change should be made in `.github/workflows/ci.yml`, by adding a block between the `name` and `on:` keys. No additional imports or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
