### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/multicollections/security/code-scanning/3](https://github.com/gerlero/multicollections/security/code-scanning/3)

To fix the problem, we should add an explicit `permissions` block to this workflow. This can be done either at the workflow root or at the job level. It's simplest, broadest, and most secure to set it at the workflow root unless specific jobs require different levels. For this workflow, which only reads code and uploads code coverage using a repository secret, the minimal required permission is `contents: read`. This limits the default `GITHUB_TOKEN` to only read repository contents, adhering to least privilege. If, in the future, a job requires more (such as creating issues or writing to packages), an explicit job-level `permissions` override can be added. The `permissions` key should be placed at the top level, beneath `name`, and before `on` or `jobs`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
