### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/gerlero/multicollections/security/code-scanning/4](https://github.com/gerlero/multicollections/security/code-scanning/4)

To resolve the problem, a `permissions` block should be added to the workflow. The block can be added either at the workflow root (applies to all jobs that lack their own `permissions`) or individually to each job. The minimal permission required for a typical test/lint/build workflow is `contents: read`. None of the jobs appear to require write access to repository contents, workflows, or other resources (since e.g., pull request annotation uploading or artifact upload is not present). Therefore, add the following at the top level (right below the workflow name), e.g., after line 1:
```yaml
permissions:
  contents: read
```
No dependency installation or code logic changes are required.  

**Required change:** Insert the `permissions:` block at the top-level in `.github/workflows/ci.yml` for least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
