### PR TITLE
Fix update() moving updated keys to the end

### DIFF
--- a/src/multicollections/__init__.py
+++ b/src/multicollections/__init__.py
@@ -7,7 +7,13 @@ from collections.abc import Iterable, Iterator, Mapping
 from typing import TypeVar, overload
 
 from ._typing import SupportsKeysAndGetItem, override
-from .abc import MultiMapping, MutableMultiMapping, _yield_items, with_default
+from .abc import (
+    MultiMapping,
+    MutableMultiMapping,
+    _updated_items,
+    _yield_items,
+    with_default,
+)
 
 __version__ = importlib.metadata.version("multicollections")
 
@@ -215,44 +221,6 @@ class MultiDict(MutableMultiMapping[_K, _V]):
         self._items.clear()
         self._key_indices.clear()
 
-    def _collect_update_items(
-        self,
-        all_items: list[tuple[_K, _V]],
-        existing_keys: set[_K],
-    ) -> tuple[dict[_K, list[_V]], list[tuple[_K, _V]]]:
-        """Separate items into updates and additions."""
-        updates_by_key: dict[_K, list[_V]] = {}  # key -> list of values to replace with
-        additions = []  # list of (key, value) for new keys
-
-        for key, value in all_items:
-            if key in existing_keys:
-                if (values_list := updates_by_key.get(key)) is None:
-                    updates_by_key[key] = values_list = []
-                values_list.append(value)
-            else:
-                additions.append((key, value))
-
-        return updates_by_key, additions
-
-    def _process_updates(self, updates_by_key: dict[_K, list[_V]]) -> None:
-        """Process updates efficiently by batch removing and adding."""
-        # Mark items for removal that need to be replaced
-        items_to_remove = set()
-        for key in updates_by_key:
-            items_to_remove.update(self._key_indices[key])
-
-        # Mark items for removal
-        for idx in items_to_remove:
-            self._items[idx] = None  # ty: ignore[invalid-assignment]
-
-        # Filter out None items
-        self._items = [item for item in self._items if item is not None]
-
-        # Add updated items (all values for each key)
-        for key, values in updates_by_key.items():
-            for value in values:
-                self._items.append((key, value))
-
     @override
     def update(
         self,
@@ -262,32 +230,17 @@ class MultiDict(MutableMultiMapping[_K, _V]):
     ) -> None:
         """Update the multi-mapping with items from another object.
 
-        This replaces existing values for keys found in the other object.
-        This is optimized for batch operations.
+        Values for keys that already exist replace them in place, keeping their
+        positions; values for new keys are appended.
         """
         # Collect all items first
-        all_items = list(_yield_items(other, **kwargs))
+        updates = list(_yield_items(other, **kwargs))
 
-        if not all_items:
+        if not updates:
             return
 
-        # Get existing keys once for efficiency
-        existing_keys = set(self._key_indices.keys())
-
-        # Separate items into updates and additions
-        updates_by_key, additions = self._collect_update_items(all_items, existing_keys)
-
-        # Process updates efficiently
-        if updates_by_key:
-            self._process_updates(updates_by_key)
-
-        # Add new items
-        if additions:
-            self._items.extend(additions)
-
-        # Rebuild indices once at the end
-        if updates_by_key or additions:
-            self._rebuild_indices()
+        self._items = _updated_items(self._items, updates, self._key_indices)
+        self._rebuild_indices()
 
     @override
     def merge(

--- a/src/multicollections/abc.py
+++ b/src/multicollections/abc.py
@@ -16,6 +16,7 @@ from collections.abc import (
     Mapping,
     MappingView,
     MutableMapping,
+    Sequence,
 )
 from collections.abc import ItemsView as MappingItemsView
 from collections.abc import KeysView as MappingKeysView
@@ -152,6 +153,49 @@ def _yield_items(
         yield from obj
 
     yield from kwargs.items()
+
+
+def _updated_items(
+    items: Iterable[tuple[_K, _V]],
+    updates: Iterable[tuple[_K, _V]],
+    /,
+    positions: Mapping[_K, Sequence[int]] | None = None,
+) -> list[tuple[_K, _V]]:
+    """Return `items` updated with `updates`.
+
+    Values from `updates` replace the items with the same key one by one, at the
+    positions those items already occupy. Any surplus values are appended at the end,
+    and any items left over for an updated key are dropped.
+
+    `positions` may be given if the indices of each key in `items` are already known.
+    """
+    ret = list(items)
+
+    if positions is None:
+        indices_by_key: dict[_K, list[int]] = {}
+        for i, (key, _) in enumerate(ret):
+            if (indices := indices_by_key.get(key)) is None:
+                indices_by_key[key] = indices = []
+            indices.append(i)
+        positions = indices_by_key
+
+    appended: list[tuple[_K, _V]] = []
+    replaced: dict[_K, int] = {}
+    for key, value in updates:
+        i = replaced.get(key, 0)
+        replaced[key] = i + 1
+        if (indices := positions.get(key)) is not None and i < len(indices):
+            ret[indices[i]] = (key, value)
+        else:
+            appended.append((key, value))
+
+    dropped = {
+        index for key, i in replaced.items() for index in positions.get(key, ())[i:]
+    }
+    if dropped:
+        ret = [item for i, item in enumerate(ret) if i not in dropped]
+
+    return ret + appended
 
 
 class MultiMapping(Mapping[_K, _V]):
@@ -326,15 +370,16 @@ class MutableMultiMapping(MultiMapping[_K, _V], MutableMapping[_K, _V]):
     ) -> None:
         """Update the multi-mapping with items from another object.
 
-        This replaces existing values for keys found in the other object.
+        Values for keys that already exist replace them in place, keeping their
+        positions; values for new keys are appended.
         """
-        existing_keys = set(self.keys())
-        for key, value in _yield_items(other, **kwargs):
-            if key in existing_keys:
-                self[key] = value
-                existing_keys.remove(key)
-            else:
-                self.add(key, value)
+        updates = list(_yield_items(other, **kwargs))
+        if not updates:
+            return
+
+        items = _updated_items(self.items(), updates)
+        self.clear()
+        self.extend(items)
 
 
 try:

--- a/tests/test_multicollections.py
+++ b/tests/test_multicollections.py
@@ -665,6 +665,7 @@ def test_update_method(
     assert md["b"] == 2  # Unchanged
     assert md["c"] == 4  # New key added
     assert md.getall("a") == [999, 5]  # Both 'a' values present
+    assert list(md.items()) == [("a", 999), ("b", 2), ("a", 5), ("c", 4)]
 
     # Test updating with dict
     md2 = cls([("x", 10), ("y", 20)])
@@ -673,6 +674,7 @@ def test_update_method(
     assert md2["x"] == 999  # Replaced
     assert md2["y"] == 20  # Unchanged
     assert md2["z"] == 30  # New key added
+    assert list(md2.items()) == [("x", 999), ("y", 20), ("z", 30)]
 
     # Test updating with kwargs
     md3 = cls([("a", 1), ("b", 2)])
@@ -681,6 +683,7 @@ def test_update_method(
     assert md3["a"] == 999  # Replaced
     assert md3["b"] == 2  # Unchanged
     assert md3["c"] == 3  # New key added
+    assert list(md3.items()) == [("a", 999), ("b", 2), ("c", 3)]
 
     # Test updating with args and kwargs
     md4 = cls([("a", 1), ("b", 2)])
@@ -690,6 +693,53 @@ def test_update_method(
     assert md4["b"] == 2  # Unchanged
     assert md4["c"] == 3  # New key added
     assert md4.getall("a") == [999, 4]  # Both 'a' values present
+    assert list(md4.items()) == [("a", 999), ("b", 2), ("c", 3), ("a", 4)]
+
+
+@pytest.mark.parametrize("cls", [MultiDict, ListMultiDict, multidict.MultiDict])
+def test_update_replaces_in_place(
+    cls: type[MultiDict[str, int] | ListMultiDict[str, int] | multidict.MultiDict[int]],
+) -> None:
+    """Test that update() replaces existing items where they are."""
+    # An updated key keeps its position
+    md = cls([("a", 1), ("b", 2), ("c", 3)])
+    md.update([("b", 99)])
+    assert list(md.items()) == [("a", 1), ("b", 99), ("c", 3)]
+
+    # Same result as assigning the key directly
+    md2 = cls([("a", 1), ("b", 2), ("c", 3)])
+    md2["b"] = 99
+    assert list(md2.items()) == list(md.items())
+
+    # Duplicates of an updated key are dropped, not moved to the end
+    md3 = cls([("a", 1), ("b", 2), ("b", 22), ("c", 3)])
+    md3.update([("b", 99)])
+    assert list(md3.items()) == [("a", 1), ("b", 99), ("c", 3)]
+
+    # Extra values fill the remaining items for the key before being appended
+    md4 = cls([("a", 1), ("b", 2), ("b", 22), ("c", 3)])
+    md4.update([("b", 99), ("b", 100), ("b", 101)])
+    assert list(md4.items()) == [("a", 1), ("b", 99), ("b", 100), ("c", 3), ("b", 101)]
+
+    # New keys are appended in the order given, after the existing items
+    md5 = cls([("a", 1), ("b", 2)])
+    md5.update([("z", 9), ("b", 99), ("y", 8)])
+    assert list(md5.items()) == [("a", 1), ("b", 99), ("z", 9), ("y", 8)]
+
+    # The values of a repeated key are consumed in the order given
+    md6 = cls([("a", 1), ("b", 2)])
+    md6.update([("b", 5), ("a", 4), ("b", 6), ("a", 7)])
+    assert list(md6.items()) == [("a", 4), ("b", 5), ("b", 6), ("a", 7)]
+
+    # Updating an empty multi-mapping just adds the items
+    md7 = cls()
+    md7.update([("a", 1), ("a", 2)])
+    assert list(md7.items()) == [("a", 1), ("a", 2)]
+
+    # An empty update leaves the items untouched
+    md8 = cls([("a", 1), ("b", 2), ("a", 3)])
+    md8.update()
+    assert list(md8.items()) == [("a", 1), ("b", 2), ("a", 3)]
 
 
 @pytest.mark.parametrize("cls", [MultiDict, ListMultiDict, dict])
@@ -1062,41 +1112,13 @@ def test_init_with_no_items_and_no_kwargs() -> None:
     assert len(md._key_indices) == 0
 
 
-def test_collect_update_items_edge_cases() -> None:
-    """Test _collect_update_items helper method edge cases."""
-    md: MultiDict[str, int] = MultiDict([("a", 1)])
+def test_update_keeps_indices_consistent() -> None:
+    """Test that update() leaves the key indices matching the items."""
+    md: MultiDict[str, int] = MultiDict([("a", 1), ("b", 2), ("a", 3), ("c", 4)])
+    md.update([("a", 999), ("d", 5), ("a", 6), ("a", 7)])
 
-    # Test with empty all_items
-    updates, additions = md._collect_update_items([], set())
-    assert updates == {}
-    assert additions == []
-
-    # Test with all new keys
-    updates, additions = md._collect_update_items([("b", 2), ("c", 3)], set())
-    assert updates == {}
-    assert additions == [("b", 2), ("c", 3)]
-
-    # Test with all existing keys
-    updates, additions = md._collect_update_items([("a", 999)], {"a"})
-    assert updates == {"a": [999]}
-    assert additions == []
-
-
-def test_process_updates_edge_cases() -> None:
-    """Test _process_updates helper method edge cases."""
-    md: MultiDict[str, int] = MultiDict([("a", 1), ("b", 2), ("a", 3)])
-    original_len = len(md)
-
-    # Test with empty updates
-    md._process_updates({})
-    assert len(md) == original_len  # Should remain unchanged
-
-    # Test with single key update - need to rebuild indices after _process_updates
-    md = MultiDict([("a", 1), ("b", 2), ("a", 3)])
-    md._process_updates({"a": [999]})
-    md._rebuild_indices()  # _process_updates doesn't rebuild indices
-    assert md["a"] == 999
-    assert md["b"] == 2
+    assert md._items == [("a", 999), ("b", 2), ("a", 6), ("c", 4), ("d", 5), ("a", 7)]
+    assert md._key_indices == {"a": [0, 2, 5], "b": [1], "c": [3], "d": [4]}
 
 
 def test_multidict_equality() -> None:


### PR DESCRIPTION
`MultiDict.update()` moves an updated key to the end instead of replacing it where it is:

```python
md = MultiDict([("a", 1), ("b", 2), ("c", 3)])
md.update({"b": 99})
# multicollections: [('a', 1), ('c', 3), ('b', 99)]
# multidict:        [('a', 1), ('b', 99), ('c', 3)]
```

`update()` regroups both the existing items and the source by key, which discards the positions of the former and the order of the latter (`MultiDict([("a", 1)]).update([("a", 2), ("b", 3), ("a", 4), ("b", 5)])` gives `[a2, a4, b3, b5]`). `__setitem__` already replaces in place for a single value, and the README's insertion-order guarantee says `update()` should too.

`MutableMultiMapping.update()` has a milder form of the same thing: it assigns the first value for a key and `add()`s the rest, so `[a1, b2, b22, c3].update([("b", 9), ("b", 10)])` gives `[a1, b9, c3, b10]` instead of `[a1, b9, b10, c3]`.

Both now go through one `_updated_items()` helper — values replace the items with that key one by one at their positions, surplus values are appended and surplus items dropped, which is what `multidict.MultiDict` does and what `__setitem__` already did for one value. `MultiDict` passes its `_key_indices` so it doesn't rebuild the index; `update()` on a 10k-item mapping is a little faster than before.

I ran `extend`, `merge`, `setdefault`, `add`, `popone`, `popall`, `pop`, `__delitem__` and `clear` against `multidict.MultiDict` over 408 (state, operation) pairs — `update()` was the only ordering divergence. `test_update_method` already ran these cases against `multidict` but never asserted on `list(md.items())`; it does now, plus `test_update_replaces_in_place` for in-place replacement, dropped duplicates, surplus values and source order. 20k random update pairs now match `multidict` exactly (9202 didn't before), and coverage is unchanged.

One thing I left alone: `popitem()` returns the *first* item and raises `StopIteration` when empty, where `dict` and `multidict` both take the last one and raise `KeyError`. Happy to do that separately if you want it aligned.
