### PR TITLE
Make popitem() remove the last item and raise KeyError when empty

### DIFF
--- a/src/multicollections/__init__.py
+++ b/src/multicollections/__init__.py
@@ -186,6 +186,27 @@ class MultiDict(MutableMultiMapping[_K, _V]):
         return value
 
     @override
+    def popitem(self) -> tuple[_K, _V]:
+        """Remove and return the last (key, value) pair.
+
+        Raises a `KeyError` if the MultiDict is empty.
+
+        This is optimized to drop the last item directly, as removing it cannot
+        shift the index of any other item.
+        """
+        if not self._items:
+            msg = "popitem(): multi-mapping is empty"
+            raise KeyError(msg)
+
+        key, value = self._items.pop()
+        indices = self._key_indices[key]
+        indices.pop()
+        if not indices:
+            del self._key_indices[key]
+
+        return key, value
+
+    @override
     def __delitem__(self, key: _K, /) -> None:
         """Remove all values for a key.
 

--- a/src/multicollections/abc.py
+++ b/src/multicollections/abc.py
@@ -317,9 +317,26 @@ class MutableMultiMapping(MultiMapping[_K, _V], MutableMapping[_K, _V]):
 
     @override
     def popitem(self) -> tuple[_K, _V]:
-        """Remove and return a (key, value) pair."""
-        key = next(iter(self))
-        value = self.popone(key)
+        """Remove and return the last (key, value) pair.
+
+        Raises a `KeyError` if the multi-mapping is empty.
+        """
+        keys = list(self)
+        if not keys:
+            msg = "popitem(): multi-mapping is empty"
+            raise KeyError(msg)
+        key = keys[-1]
+
+        values = self.getall(key)
+        if len(values) == 1:
+            # Only item for this key, so `popone` removes this one.
+            return key, self.popone(key)
+
+        # `popone` would remove an earlier item for the same key, so rebuild instead.
+        items = list(self.items())
+        value = items.pop()[1]
+        self.clear()
+        self.extend(items)
         return key, value
 
     @override

--- a/tests/test_multicollections.py
+++ b/tests/test_multicollections.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+
 import multidict
 import pytest
 
@@ -496,10 +498,10 @@ def test_popitem_method(
     md = cls([("a", 1), ("b", 2), ("a", 3)])
     original_len = len(md)
 
-    # Test popping first item (value may differ between implementations)
+    # Test popping the last item
     key, value = md.popitem()
     assert key == "a"
-    assert value in [1, 3]  # Different implementations may return different values
+    assert value == 3
     assert len(md) == original_len - 1
 
     # Test popping from single-item dict
@@ -511,10 +513,93 @@ def test_popitem_method(
 
     # Test empty MultiDict
     empty_md = cls()
-    with pytest.raises(
-        (StopIteration, KeyError)
-    ):  # Different implementations may raise different errors
+    with pytest.raises(KeyError):
         empty_md.popitem()
+
+
+@pytest.mark.parametrize("cls", [MultiDict, ListMultiDict, multidict.MultiDict])
+@pytest.mark.parametrize(
+    "items",
+    [
+        [("a", 1)],
+        [("a", 1), ("b", 2)],
+        [("a", 1), ("b", 2), ("c", 3)],
+        [("a", 1), ("a", 2)],
+        [("a", 1), ("b", 2), ("a", 3)],
+        [("b", 2), ("a", 1), ("b", 22)],
+        [("x", 0), ("y", 1), ("x", 2), ("z", 3), ("y", 4), ("x", 5)],
+    ],
+)
+def test_popitem_removes_the_last_item(
+    cls: type[MultiDict[str, int] | ListMultiDict[str, int] | multidict.MultiDict[int]],
+    items: list[tuple[str, int]],
+) -> None:
+    """popitem() takes the last item, like dict and multidict."""
+    md = cls(items)
+
+    assert md.popitem() == items[-1]
+    assert list(md.items()) == items[:-1]
+
+
+@pytest.mark.parametrize("cls", [MultiDict, ListMultiDict, multidict.MultiDict])
+def test_popitem_drains_in_reverse_order(
+    cls: type[MultiDict[str, int] | ListMultiDict[str, int] | multidict.MultiDict[int]],
+) -> None:
+    """Repeated popitem() calls unwind the multi-mapping."""
+    items = [("a", 1), ("b", 2), ("a", 3), ("c", 4)]
+    md = cls(items)
+
+    assert [md.popitem() for _ in range(len(items))] == items[::-1]
+    assert len(md) == 0
+
+
+@pytest.mark.parametrize("cls", [MultiDict, ListMultiDict, multidict.MultiDict])
+def test_popitem_takes_the_last_item_for_a_repeated_key(
+    cls: type[MultiDict[str, int] | ListMultiDict[str, int] | multidict.MultiDict[int]],
+) -> None:
+    """The last item wins even when earlier items share its key."""
+    md = cls([("a", 1), ("b", 2)])
+    md.add("a", 3)
+
+    assert md.popitem() == ("a", 3)
+    assert list(md.items()) == [("a", 1), ("b", 2)]
+
+
+@pytest.mark.parametrize("cls", [MultiDict, ListMultiDict, multidict.MultiDict])
+def test_popitem_forgets_the_key_of_the_popped_item(
+    cls: type[MultiDict[str, int] | ListMultiDict[str, int] | multidict.MultiDict[int]],
+) -> None:
+    """Popping a key's only item removes the key itself."""
+    md = cls([("a", 1), ("b", 2)])
+
+    assert md.popitem() == ("b", 2)
+    assert "b" not in md
+    with pytest.raises(KeyError):
+        md["b"]
+
+    assert md.popitem() == ("a", 1)
+    assert "a" not in md
+    assert len(md) == 0
+
+
+@pytest.mark.parametrize("cls", [MultiDict, ListMultiDict, multidict.MultiDict])
+def test_popitem_on_empty_raises_key_error(
+    cls: type[MultiDict[str, int] | ListMultiDict[str, int] | multidict.MultiDict[int]],
+) -> None:
+    """An empty multi-mapping raises KeyError, not StopIteration."""
+    md = cls()
+
+    with pytest.raises(KeyError):
+        md.popitem()
+
+    # A leaked StopIteration would end this loop early instead of propagating.
+    def drain() -> Iterator[tuple[str, int]]:
+        while True:
+            yield md.popitem()
+
+    md.add("a", 1)
+    with pytest.raises(KeyError):
+        list(drain())
 
 
 @pytest.mark.parametrize("cls", [MultiDict, ListMultiDict, multidict.MultiDict])


### PR DESCRIPTION
`popitem()` returns the *first* item, but `dict` and `multidict.MultiDict` — the implementation the tests parametrise against — both return the last one. And on an empty multi-mapping the bare `StopIteration` from `next(iter(self))` escapes instead of the `KeyError` `MutableMapping` promises:

```python
>>> MultiDict([("a", 1), ("b", 2)]).popitem()
('a', 1)          # multidict: ('b', 2)
>>> MultiDict().popitem()
StopIteration     # multidict: KeyError
```

The `StopIteration` half is the sharper one: it walks straight out of the usual `while True: ... except KeyError` drain loop, and inside a generator PEP 479 turns it into `RuntimeError: generator raised StopIteration`. `getone()` already wraps the same `next(iter(...))` in a `try`/`except StopIteration` — `popitem()` was the only other reachable bare-`next` site in the package and didn't.

Fixed in `abc.py` so both `MultiDict` and the abc default pick it up, same shape as #122. One subtlety worth flagging: taking the last *key* and calling `popone(key)` is not enough, because `popone` removes the *first* item for that key — `[("a", 1), ("b", 2)]` plus `add("a", 3)` would pop `("a", 1)`. The default rebuilds in that case; `MultiDict` gets an O(1) override since it can drop the last item without shifting any other index.

I re-ran the differential harness from #122 over the whole surface (572 (state, operation) pairs against `multidict`, read and mutating): the `popitem` family was the only remaining divergence, at 76 pairs, and is now at zero. The new tests follow the existing parametrised style, so `multidict` has to satisfy the same assertions; `test_popitem_method` no longer accepts either end or either exception.

Follow-up to #122, where you said to go ahead with this one.
